### PR TITLE
NP-2539 DEFAULT_STORAGE_SIZE setting creating 

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -117,12 +117,12 @@
   version = "v0.0.30"
 
 [[projects]]
-  digest = "1:72ac554d3a65bb7182facea97d8edd0d679df14984c66b1110da0eda47441e7b"
+  digest = "1:7e26a8f455c4e7978f049bd0c2e53f7f1195e15f66fe1ba9f11bd278105ef803"
   name = "github.com/nalej/grpc-organization-go"
   packages = ["."]
   pruneopts = ""
-  revision = "448507f75afa7dd6c13a4481970bef0fb6383d39"
-  version = "v0.0.33"
+  revision = "db43aba4f994f9c1b4740ff1c6126c636d5f5dd0"
+  version = "v0.0.34"
 
 [[projects]]
   digest = "1:e93099df7b2c493f8a4cb0ff1e0948b382348ab07850d72480a7ebe406ed8d09"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -24,7 +24,7 @@
 
 [[constraint]]
     name="github.com/nalej/grpc-organization-go"
-    version="=v0.0.33"
+    version="=v0.0.34"
 
 [[constraint]]
     name="github.com/nalej/grpc-organization-manager-go"

--- a/internal/app/signup/server/signup/manager.go
+++ b/internal/app/signup/server/signup/manager.go
@@ -33,7 +33,7 @@ import (
 )
 
 const DefaultStorageAllocationSize = 100 * 1024 * 1024
-const DefaultStorageAllocationSizeDesc = "Default Storage Size"
+const DefaultStorageAllocationSizeDesc = "Default Storage Size (bytes)"
 
 // DefaultRoles defines the map of roles that will be automatically created by the system by default.
 var DefaultRoles = map[string][]grpc_authx_go.AccessPrimitive{


### PR DESCRIPTION
#### What does this PR do?
Adds DEFAULT_STORAGE_SIZE when creating an organization
#### Where should the reviewer start?

#### What is missing?

#### How should this be manually tested?
executing:
```
./bin/signup-cli signup --nalejAdminEmail admin3@nalej.com --nalejAdminName admin3 --nalejAdminPassword*** --orgName Nalej3 --ownerEmail owner3@nalej.com --ownerName owner3 --ownerPassword *** --signupAddress signup.***.nalej.tech:443 --consoleLogging --debug --caPath <caPath>
```
check the setting is added
```
organization_id                      | key                  | description             | value
--------------------------------------+----------------------+-------------------------+------------
 3bf57e86-e9c1-4809-82d1-174052fda2b4 | DEFAULT_STORAGE_SIZE |    Default Storage Size |  104857600
```
#### Any background context you want to provide?

#### What are the relevant tickets?

- [NP-2539](https://nalej.atlassian.net/browse/NP-2539)

#### Screenshots (if appropriate)

#### Questions
